### PR TITLE
ci: add release workflows

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,15 @@
+---
+name: Lint PR
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+jobs:
+  trigger:
+    uses: statnett/workflows/.github/workflows/lint-pr.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,5 @@
 ---
 name: Release Please
-
 on:
   push:
     branches:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,17 @@
+---
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger:
+    uses: statnett/workflows/.github/workflows/release-please.yml@main
+    with:
+      release-type: maven
+    secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
This adds two reusable workflows from https://github.com/statnett/workflows/tree/main/.github/workflows:

1. Lint PR titles to ensure we use conventional commits (to get a good changelog)
2. Release Please with the Maven release type, ref. https://github.com/googleapis/release-please#strategy-language-types-supported