### PR TITLE
ci: allow release-please workflow to be triggered manually

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   trigger:


### PR DESCRIPTION
Release Please is having some issues from time to time. This change allows the workflow to be triggered manually from the UI - if needed.