### PR TITLE
chore: allow setting Prometheus metric prefix

### DIFF
--- a/src/main/java/no/statnett/k3alagexporter/Conf.java
+++ b/src/main/java/no/statnett/k3alagexporter/Conf.java
@@ -24,8 +24,8 @@ public final class Conf {
         return conf.getInt(MAIN_OBJECT_NAME + ".reporters.prometheus.port");
     }
 
-    public static String getPrometheusMetricPrefix() {
-        return conf.getString(MAIN_OBJECT_NAME + ".reporters.prometheus.metric-prefix");
+    public static String getPrometheusMetricNamespace() {
+        return conf.getString(MAIN_OBJECT_NAME + ".reporters.prometheus.metric-namespace");
     }
 
     public static String getClusterName() {

--- a/src/main/java/no/statnett/k3alagexporter/Conf.java
+++ b/src/main/java/no/statnett/k3alagexporter/Conf.java
@@ -24,6 +24,10 @@ public final class Conf {
         return conf.getInt(MAIN_OBJECT_NAME + ".reporters.prometheus.port");
     }
 
+    public static String getPrometheusMetricPrefix() {
+        return conf.getString(MAIN_OBJECT_NAME + ".reporters.prometheus.metric-prefix");
+    }
+
     public static String getClusterName() {
         return getCluster().getString("name");
     }

--- a/src/main/java/no/statnett/k3alagexporter/PrometheusReporter.java
+++ b/src/main/java/no/statnett/k3alagexporter/PrometheusReporter.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 public final class PrometheusReporter {
 
-    public static final String PROMETHEUS_PREFIX = "k3a_";
+    public static final String PROMETHEUS_PREFIX = Conf.getPrometheusMetricPrefix();
     private final Gauge consumerGroupLagGauge = Gauge.builder()
         .name(PROMETHEUS_PREFIX + "consumergroup_group_lag")
         .labelNames("cluster_name", "group", "topic", "partition" /*, "member_host", "consumer_id", "client_id" */)

--- a/src/main/java/no/statnett/k3alagexporter/PrometheusReporter.java
+++ b/src/main/java/no/statnett/k3alagexporter/PrometheusReporter.java
@@ -10,14 +10,14 @@ import java.io.IOException;
 
 public final class PrometheusReporter {
 
-    public static final String PROMETHEUS_PREFIX = Conf.getPrometheusMetricPrefix();
+    private static final String PROMETHEUS_NAMESPACE = Conf.getPrometheusMetricNamespace();
     private final Gauge consumerGroupLagGauge = Gauge.builder()
-        .name(PROMETHEUS_PREFIX + "consumergroup_group_lag")
+        .name(buildPrometheusFQName(PROMETHEUS_NAMESPACE, "consumergroup", "group_lag"))
         .labelNames("cluster_name", "group", "topic", "partition" /*, "member_host", "consumer_id", "client_id" */)
         .help("Group offset lag of a partition")
         .register();
     private final Gauge pollTimeMsGauge = Gauge.builder()
-        .name(PROMETHEUS_PREFIX + "lag_exporter_poll_time_ms")
+        .name(buildPrometheusFQName(PROMETHEUS_NAMESPACE, "lag_exporter", "poll_time_ms"))
         .labelNames("cluster_name")
         .help("Time (in ms) spent polling all data")
         .register();
@@ -61,6 +61,10 @@ public final class PrometheusReporter {
                 .labelValues(clusterName)
                 .set(clusterData.getPollTimeMs());
         }
+    }
+
+    private String buildPrometheusFQName(final String namespace, final String subsystem, final String name) {
+        return namespace + "_" + subsystem + "_" + name;
     }
 
 }

--- a/src/main/java/no/statnett/k3alagexporter/PrometheusReporter.java
+++ b/src/main/java/no/statnett/k3alagexporter/PrometheusReporter.java
@@ -63,7 +63,7 @@ public final class PrometheusReporter {
         }
     }
 
-    private String buildPrometheusFQName(final String namespace, final String subsystem, final String name) {
+    private static String buildPrometheusFQName(final String namespace, final String subsystem, final String name) {
         return namespace + "_" + subsystem + "_" + name;
     }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 k3a-lag-exporter {
     poll-interval = 30 seconds
     reporters.prometheus.port = 8000
-    reporters.prometheus.metric-namespace = "k3a_"
+    reporters.prometheus.metric-namespace = "k3a"
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,5 @@
 k3a-lag-exporter {
     poll-interval = 30 seconds
     reporters.prometheus.port = 8000
+    reporters.prometheus.metric-prefix = "k3a_"
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 k3a-lag-exporter {
     poll-interval = 30 seconds
     reporters.prometheus.port = 8000
-    reporters.prometheus.metric-prefix = "k3a_"
+    reporters.prometheus.metric-namespace = "k3a_"
 }


### PR DESCRIPTION
For metric-level compatibility with kafka-lag-exporter, change the metric prefix by adding this to the configuration:

```text
reporters.prometheus.metric-namespace = "kafka"
```
