### PR TITLE
feat!: rename configuration properties

### DIFF
--- a/src/main/java/no/statnett/k3alagexporter/Conf.java
+++ b/src/main/java/no/statnett/k3alagexporter/Conf.java
@@ -18,7 +18,7 @@ public final class Conf {
 
     private static final Config DEFAULT_CONFIG = ConfigFactory.parseResources("reference.conf");
     private static Config conf = ConfigFactory.load();
-    private static final String MAIN_OBJECT_NAME = "kafka-lag-exporter";
+    private static final String MAIN_OBJECT_NAME = "k3a-lag-exporter";
 
     public static int getPrometheusPort() {
         return conf.getInt(MAIN_OBJECT_NAME + ".reporters.prometheus.port");
@@ -37,13 +37,13 @@ public final class Conf {
     }
 
     public static Map<String, Object> getAdminConfigs() {
-        final Map<String, Object> map = configToMap(getCluster().getConfig("admin-client-properties"));
+        final Map<String, Object> map = configToMap(getCluster().getConfig("admin-properties"));
         map.putIfAbsent(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
         return map;
     }
 
     public static String getBootstrapServers() {
-        return getCluster().getString("bootstrap-brokers");
+        return getCluster().getString("bootstrap-servers");
     }
 
     public static long getPollIntervalMs() {
@@ -51,19 +51,19 @@ public final class Conf {
     }
 
     public static Collection<String> getConsumerGroupDenyList() {
-        return getStringCollectionOrNull(getCluster(), "group-blacklist");
+        return getStringCollectionOrNull(getCluster(), "group-deny-list");
     }
 
     public static Collection<String> getConsumerGroupAllowList() {
-        return getStringCollectionOrNull(getCluster(), "group-whitelist");
+        return getStringCollectionOrNull(getCluster(), "group-allow-list");
     }
 
     public static Collection<String> getTopicDenyList() {
-        return getStringCollectionOrNull(getCluster(), "topic-blacklist");
+        return getStringCollectionOrNull(getCluster(), "topic-deny-list");
     }
 
     public static Collection<String> getTopicAllowList() {
-        return getStringCollectionOrNull(getCluster(), "topic-whitelist");
+        return getStringCollectionOrNull(getCluster(), "topic-allow-list");
     }
 
     private static Collection<String> getStringCollectionOrNull(final Config config, final String name) {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-kafka-lag-exporter {
+k3a-lag-exporter {
     poll-interval = 30 seconds
     reporters.prometheus.port = 8000
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,19 +1,19 @@
-kafka-lag-exporter {
+k3a-lag-exporter {
     port = 8000
     clusters = [
     {
         name = "the-kafka-cluster"
-        bootstrap-brokers = "kafka.example.com:9092"
-        topic-whitelist = [
+        bootstrap-servers = "kafka.example.com:9092"
+        topic-allow-list = [
             "topic1"
             "topic2"
         ]
-        group-whitelist = [
+        group-allow-list = [
             "group1"
             "group2"
             ".*group"
         ]
-         consumer-properties = {
+        consumer-properties = {
             security.protocol = SSL
             ssl.truststore.type = "PKCS12"
             ssl.truststore.location = "./foo.jks"
@@ -22,7 +22,7 @@ kafka-lag-exporter {
             ssl.keystore.location = "./bar.jks"
             ssl.keystore.password = "password"
         }
-        admin-client-properties = {
+        admin-properties = {
             security.protocol = SSL
             ssl.truststore.type = "PKCS12"
             ssl.truststore.location = "./foo.jks"


### PR DESCRIPTION
Changes to configuration file properties

| Old name | New name |
|------------|-------------|
| `kafka-lag-exporter` | `k3a-lag-exporter` |
| `admin-client-properties` | `admin-properties` |
| `bootstrap-brokers` | `bootstrap-servers` |
| `group-blacklist` | `group-deny-list` |
| `group-whitelist` | `group-allow-list` |
| `topic-blacklist` | `topic-deny-list` |
| `topic-whitelist` | `topic-allow-list` |

BREAKING CHANGE: Users must rewrite their configuration files.