### PR TITLE
ci(fix): make clean GHCR workflow inherit secrets

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -10,5 +10,6 @@ jobs:
     uses: statnett/workflows/.github/workflows/clean-ghcr.yaml@main
     with:
       image-names: ${{ github.repository }}
+    secrets: inherit
     permissions:
       packages: write


### PR DESCRIPTION
To adjust for this change: https://github.com/statnett/workflows/pull/6