### PR TITLE
ci(fix): correct value for image name

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -9,7 +9,7 @@ jobs:
   trigger:
     uses: statnett/workflows/.github/workflows/clean-ghcr.yaml@main
     with:
-      image-names: ${{ github.repository }}
+      image-names: ${{ github.event.repository.name }}
     secrets: inherit
     permissions:
       packages: write


### PR DESCRIPTION
It turns out that `github.repository` contains the org-name - which won't work here. Trying with the "common" even property `github.event.repository.name`.