### PR TITLE
ci: disable schedule for GHCR cleanup for now

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -1,8 +1,10 @@
 ---
 name: Delete Obsolete GHCR Images
 on:
-  schedule:
-    - cron: "0 1 * * *"  # every day at midnight
+# FIXME: Create (classic) PAT to make GHCR cleanup work.
+# Ref. https://github.com/statnett/workflows/blob/main/.github/workflows/clean-ghcr.yaml#L18-L22
+#  schedule:
+#    - cron: "0 1 * * *"  # every day at midnight
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Noen™️ has to set up a (classic) PAT to make the GHCR cleanup work. Disabling it for now.