### PR TITLE
fix(release): push image for tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 
 jobs:
   build-push-image:


### PR DESCRIPTION
It seems like the main workflow wasn't configured to run for tags.

Close #32 