### PR TITLE
fix: log to single lines

### DIFF
--- a/src/main/java/no/statnett/k3alagexporter/K3aLagExporter.java
+++ b/src/main/java/no/statnett/k3alagexporter/K3aLagExporter.java
@@ -1,38 +1,11 @@
 package no.statnett.k3alagexporter;
 
 import no.statnett.k3alagexporter.model.ClusterData;
+import no.statnett.k3alagexporter.utils.LogUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class K3aLagExporter {
-
-    private static final Logger LOG = LoggerFactory.getLogger(K3aLagExporter.class);
-
-    private void doit() {
-        try {
-            final long msBetweenCollections = Conf.getPollIntervalMs();
-            final PrometheusReporter prometheusReporter = new PrometheusReporter();
-            prometheusReporter.start();
-            final ClusterLagCollector collector = new ClusterLagCollector(Conf.getClusterName(),
-                                                                          Conf.getTopicAllowList(), Conf.getTopicDenyList(),
-                                                                          Conf.getConsumerGroupAllowList(), Conf.getConsumerGroupDenyList(),
-                                                                          Conf.getConsumerConfig(), Conf.getAdminConfig());
-            for (;;) {
-                long t = System.currentTimeMillis();
-                final ClusterData clusterData = collector.collect();
-                prometheusReporter.publish(clusterData);
-                t = System.currentTimeMillis() - t;
-                try {
-                    Thread.sleep(Math.max(0, msBetweenCollections - t));
-                } catch (final InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        } catch (final Exception e) {
-            LOG.error("Fatal error. Terminating.", e);
-            System.exit(1);
-        }
-    }
 
     private static void showHelpAndExit() {
         System.out.println("For configuration and usage of k3a-lag-exporter, please see");
@@ -41,6 +14,7 @@ public final class K3aLagExporter {
     }
 
     public static void main(final String[] args) {
+        LogUtils.enableSingleLineLogging();
         if (args.length != 0) {
             showHelpAndExit();
         }
@@ -50,7 +24,7 @@ public final class K3aLagExporter {
             System.exit(1);
         }
         Conf.setFromFile(configFile);
-        new K3aLagExporter().doit();
+        new MainLagExporterLoop().runLoop();
     }
 
 }

--- a/src/main/java/no/statnett/k3alagexporter/K3aLagExporter.java
+++ b/src/main/java/no/statnett/k3alagexporter/K3aLagExporter.java
@@ -14,7 +14,7 @@ public final class K3aLagExporter {
     }
 
     public static void main(final String[] args) {
-        LogUtils.enableSingleLineLogging();
+        LogUtils.initLogging();
         if (args.length != 0) {
             showHelpAndExit();
         }

--- a/src/main/java/no/statnett/k3alagexporter/MainLagExporterLoop.java
+++ b/src/main/java/no/statnett/k3alagexporter/MainLagExporterLoop.java
@@ -1,0 +1,38 @@
+package no.statnett.k3alagexporter;
+
+import no.statnett.k3alagexporter.model.ClusterData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class MainLagExporterLoop {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MainLagExporterLoop.class);
+
+    public void runLoop() {
+        try {
+            final long msBetweenCollections = Conf.getPollIntervalMs();
+            LOG.info("Starting polling every " + msBetweenCollections + " ms");
+            final PrometheusReporter prometheusReporter = new PrometheusReporter();
+            prometheusReporter.start();
+            final ClusterLagCollector collector = new ClusterLagCollector(Conf.getClusterName(),
+                                                                          Conf.getTopicAllowList(), Conf.getTopicDenyList(),
+                                                                          Conf.getConsumerGroupAllowList(), Conf.getConsumerGroupDenyList(),
+                                                                          Conf.getConsumerConfig(), Conf.getAdminConfig());
+            for (;;) {
+                long t = System.currentTimeMillis();
+                final ClusterData clusterData = collector.collect();
+                prometheusReporter.publish(clusterData);
+                t = System.currentTimeMillis() - t;
+                try {
+                    Thread.sleep(Math.max(0, msBetweenCollections - t));
+                } catch (final InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        } catch (final Exception e) {
+            LOG.error("Fatal error. Terminating.", e);
+            System.exit(1);
+        }
+    }
+
+}

--- a/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
+++ b/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
@@ -11,6 +11,6 @@ public final class LogUtils {
      */
     public static void enableSingleLineLogging() {
         System.setProperty("java.util.logging.SimpleFormatter.format",
-                           "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n");
+                           "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s: %5$s%6$s%n");
     }
 }

--- a/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
+++ b/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
@@ -1,0 +1,16 @@
+package no.statnett.k3alagexporter.utils;
+
+public final class LogUtils {
+
+    private LogUtils() {
+    }
+
+    /**
+     * Sets up logging to a single line when using Java Logging.
+     * Must be called before any log-related class is instantiated.
+     */
+    public static void enableSingleLineLogging() {
+        System.setProperty("java.util.logging.SimpleFormatter.format",
+                           "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n");
+    }
+}

--- a/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
+++ b/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
@@ -2,6 +2,8 @@ package no.statnett.k3alagexporter.utils;
 
 public final class LogUtils {
 
+    public static final String LOG_FORMAT_PROPERTY = "java.util.logging.SimpleFormatter.format";
+
     private LogUtils() {
     }
 
@@ -10,7 +12,8 @@ public final class LogUtils {
      * Must be called before any log-related class is instantiated.
      */
     public static void enableSingleLineLogging() {
-        System.setProperty("java.util.logging.SimpleFormatter.format",
-                           "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s: %5$s%6$s%n");
+        if (System.getProperty(LOG_FORMAT_PROPERTY) == null) {
+            System.setProperty(LOG_FORMAT_PROPERTY, "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s: %5$s%6$s%n");
+        }
     }
 }

--- a/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
+++ b/src/main/java/no/statnett/k3alagexporter/utils/LogUtils.java
@@ -11,7 +11,7 @@ public final class LogUtils {
      * Sets up logging to a single line when using Java Logging.
      * Must be called before any log-related class is instantiated.
      */
-    public static void enableSingleLineLogging() {
+    public static void initLogging() {
         if (System.getProperty(LOG_FORMAT_PROPERTY) == null) {
             System.setProperty(LOG_FORMAT_PROPERTY, "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s: %5$s%6$s%n");
         }

--- a/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
+++ b/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
@@ -5,6 +5,7 @@ import no.statnett.k3alagexporter.itest.services.KafkaCluster;
 import no.statnett.k3alagexporter.model.ClusterData;
 import no.statnett.k3alagexporter.model.ConsumerGroupData;
 import no.statnett.k3alagexporter.model.TopicPartitionData;
+import no.statnett.k3alagexporter.utils.LogUtils;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -31,6 +32,7 @@ public final class K3aLagExporterIT {
 
     @BeforeClass
     public static void beforeClass() {
+        LogUtils.enableSingleLineLogging();
         kafkaCluster = new KafkaCluster();
         kafkaCluster.start();
         lagCollector = new ClusterLagCollector(CLUSTER_NAME,

--- a/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
+++ b/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
@@ -32,7 +32,7 @@ public final class K3aLagExporterIT {
 
     @BeforeClass
     public static void beforeClass() {
-        LogUtils.enableSingleLineLogging();
+        LogUtils.initLogging();
         kafkaCluster = new KafkaCluster();
         kafkaCluster.start();
         lagCollector = new ClusterLagCollector(CLUSTER_NAME,


### PR DESCRIPTION
Changes log output from

```text
okt. 03, 2023 7:08:58 A.M. org.apache.kafka.common.metrics.Metrics close
INFO: Metrics reporters closed
```

to

```text
2023-10-03 07:09:47 INFO org.apache.kafka.common.metrics.Metrics close: Metrics reporters closed
```
