### PR TITLE
ci: attempt to fix lint-pr workflow

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -5,11 +5,11 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 jobs:
   trigger:
     uses: statnett/workflows/.github/workflows/lint-pr.yml@main
     permissions:
-      contents: read
       pull-requests: write
       statuses: write


### PR DESCRIPTION
I have a feeling it might be the missing `synchronize` type that is causing the issues with missed triggers on this workflow. Also removing a permission that is not required.