### PR TITLE
ci: fix broken links to reusable workflows

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -2,14 +2,14 @@
 name: Delete Obsolete GHCR Images
 on:
 # FIXME: Create (classic) PAT to make GHCR cleanup work.
-# Ref. https://github.com/statnett/workflows/blob/main/.github/workflows/clean-ghcr.yaml#L18-L22
+# Ref. https://github.com/statnett/github-workflows/blob/main/.github/workflows/clean-ghcr.yaml#L18-L22
 #  schedule:
 #    - cron: "0 1 * * *"  # every day at midnight
   workflow_dispatch:
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/clean-ghcr.yaml@main
+    uses: statnett/github-workflows/.github/workflows/clean-ghcr.yaml@main
     with:
       image-names: ${{ github.event.repository.name }}
     secrets: inherit

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/lint-pr.yml@main
+    uses: statnett/github-workflows/.github/workflows/lint-pr.yaml@main
     permissions:
       pull-requests: write
       statuses: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/release-please.yml@main
+    uses: statnett/github-workflows/.github/workflows/release-please.yaml@main
     with:
       release-type: maven
     secrets: inherit


### PR DESCRIPTION
We have renamed the reusable GitHub workflow project and standardized on .yaml as file extensions. This updates what's needed to follow after.