### PR TITLE
test: upgrade to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -42,9 +54,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/no/statnett/k3alagexporter/ConfTest.java
+++ b/src/test/java/no/statnett/k3alagexporter/ConfTest.java
@@ -1,53 +1,56 @@
 package no.statnett.k3alagexporter;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ConfTest {
 
     @Test
     public void shouldFindPrometheusPort() {
-        Assert.assertEquals(8000, Conf.getPrometheusPort());
+        assertEquals(8000, Conf.getPrometheusPort());
     }
 
     @Test
     public void shouldFindClusterName() {
-        Assert.assertEquals("the-kafka-cluster", Conf.getClusterName());
+        assertEquals("the-kafka-cluster", Conf.getClusterName());
     }
 
     @Test
     public void shouldFindConsumerProperties() {
         final Map<String, Object> map = Conf.getConsumerConfig();
-        Assert.assertNotNull(map);
-        Assert.assertEquals("SSL", map.get("security.protocol"));
+        assertNotNull(map);
+        assertEquals("SSL", map.get("security.protocol"));
     }
 
     @Test
     public void shouldFindAdminProperties() {
         final Map<String, Object> map = Conf.getAdminConfig();
-        Assert.assertNotNull(map);
-        Assert.assertEquals("password", map.get("ssl.keystore.password"));
+        assertNotNull(map);
+        assertEquals("password", map.get("ssl.keystore.password"));
     }
 
     @Test
     public void shouldFindPollInterval() {
-        Assert.assertEquals(30000L, Conf.getPollIntervalMs());
+        assertEquals(30000L, Conf.getPollIntervalMs());
     }
 
     @Test
     public void shouldFindBootstrapServers() {
-        Assert.assertEquals("kafka.example.com:9092", Conf.getBootstrapServers());
+        assertEquals("kafka.example.com:9092", Conf.getBootstrapServers());
     }
 
     @Test
     public void shouldFindTopicAllowList() {
         final Collection<String> list = Conf.getTopicAllowList();
-        Assert.assertNotNull(list);
-        Assert.assertTrue(list.contains("topic1"));
-        Assert.assertEquals(2, list.size());
+        assertNotNull(list);
+        assertTrue(list.contains("topic1"));
+        assertEquals(2, list.size());
     }
 
 }

--- a/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
+++ b/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
@@ -12,14 +12,16 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public final class K3aLagExporterIT {
 
@@ -30,17 +32,17 @@ public final class K3aLagExporterIT {
     private static ClusterLagCollector lagCollector;
     private int nextProducedValue = 0;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         LogUtils.initLogging();
         kafkaCluster = new KafkaCluster();
         kafkaCluster.start();
         lagCollector = new ClusterLagCollector(CLUSTER_NAME,
-                                               null, null, null, null,
-                                               kafkaCluster.getMinimalConsumerConfig(), kafkaCluster.getMinimalAdminConfig());
+            null, null, null, null,
+            kafkaCluster.getMinimalConsumerConfig(), kafkaCluster.getMinimalAdminConfig());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         kafkaCluster.stop();
     }
@@ -52,7 +54,7 @@ public final class K3aLagExporterIT {
                 consumer.subscribe(Collections.singleton(TOPIC));
                 produce(producer);
                 final int consumedValue = consume(consumer);
-                Assert.assertEquals(nextProducedValue - 1, consumedValue);
+                assertEquals(nextProducedValue - 1, consumedValue);
                 assertLag(0);
                 produce(producer);
                 assertLag(1);
@@ -71,10 +73,10 @@ public final class K3aLagExporterIT {
     private void assertLag(final int expected) {
         final ClusterData clusterData = lagCollector.collect();
         final TopicPartitionData topicPartitionData = clusterData.findTopicPartitionData(new TopicPartition(TOPIC, 0));
-        Assert.assertNotNull(topicPartitionData);
+        assertNotNull(topicPartitionData);
         final ConsumerGroupData consumerGroupData = topicPartitionData.findConsumerGroupData(CONSUMER_GROUP_ID);
-        Assert.assertNotNull(consumerGroupData);
-        Assert.assertEquals(expected, consumerGroupData.getLag(), 0.00001);
+        assertNotNull(consumerGroupData);
+        assertEquals(expected, consumerGroupData.getLag(), 0.00001);
     }
 
     private void produce(final Producer<Integer, Integer> producer) {

--- a/src/test/java/no/statnett/k3alagexporter/utils/RegexStringListFilterTest.java
+++ b/src/test/java/no/statnett/k3alagexporter/utils/RegexStringListFilterTest.java
@@ -1,51 +1,53 @@
 package no.statnett.k3alagexporter.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class RegexStringListFilterTest {
 
     @Test
     public void shouldAllowForEmptyLists() {
-        Assert.assertTrue(isAllowed(Collections.emptyList(), Collections.emptyList(), "foo"));
+        assertTrue(isAllowed(Collections.emptyList(), Collections.emptyList(), "foo"));
     }
 
     @Test
     public void shouldAllowForNullLists() {
-        Assert.assertTrue(isAllowed(null, null, "foo"));
+        assertTrue(isAllowed(null, null, "foo"));
     }
 
     @Test
     public void shouldBeImplicitlyAnchored() {
-        Assert.assertTrue(isAllowed(null, Collections.singleton("foo"), "foobar"));
+        assertTrue(isAllowed(null, Collections.singleton("foo"), "foobar"));
     }
 
     @Test
     public void shouldDenyExactMatch() {
-        Assert.assertFalse(isAllowed(null, Collections.singleton("foo"), "foo"));
+        assertFalse(isAllowed(null, Collections.singleton("foo"), "foo"));
     }
 
     @Test
     public void shouldDenyWhenBothAllowedAndDenied() {
-        Assert.assertFalse(isAllowed(Collections.singleton("foo"), Collections.singleton("foo"), "foo"));
+        assertFalse(isAllowed(Collections.singleton("foo"), Collections.singleton("foo"), "foo"));
     }
 
     @Test
     public void shouldAllowWhenAllowedAndNotDenied() {
-        Assert.assertTrue(isAllowed(Collections.singleton("foo"), Collections.singleton("bar"), "foo"));
+        assertTrue(isAllowed(Collections.singleton("foo"), Collections.singleton("bar"), "foo"));
     }
 
     @Test
     public void shouldDenyWhenNotInAllowList() {
-        Assert.assertFalse(isAllowed(Collections.singleton("foo"), null, "bar"));
+        assertFalse(isAllowed(Collections.singleton("foo"), null, "bar"));
     }
 
     @Test
     public void shouldAllowWhenRegexMatch() {
-        Assert.assertTrue(isAllowed(Collections.singleton("foo.*"), null, "foobar"));
+        assertTrue(isAllowed(Collections.singleton("foo.*"), null, "foobar"));
     }
 
     private boolean isAllowed(final Collection<String> allowRegexList, final Collection<String> denyRegexList, final String s) {


### PR DESCRIPTION
I would like to try out some embedded Kafka brokers for integration tests, and most of them work better with JUnit 5.