### PR TITLE
chore: don't poll more times than necessary

### DIFF
--- a/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
+++ b/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
@@ -97,7 +97,7 @@ public final class K3aLagExporterIT {
 
     private int consume(final Consumer<Integer, Integer> consumer) {
         int lastValue = -1;
-        final ConsumerRecords<Integer, Integer> records = consumer.poll(Duration.ofMillis(1000));
+        final ConsumerRecords<Integer, Integer> records = consumer.poll(Duration.ofMillis(300));
         for (final ConsumerRecord<Integer, Integer> record : records) {
             lastValue = record.value();
             consumer.commitAsync();

--- a/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
+++ b/src/test/java/no/statnett/k3alagexporter/itest/K3aLagExporterIT.java
@@ -53,7 +53,7 @@ public final class K3aLagExporterIT {
             try (final Consumer<Integer, Integer> consumer = kafkaCluster.getConsumer(CONSUMER_GROUP_ID)) {
                 consumer.subscribe(Collections.singleton(TOPIC));
                 produce(producer);
-                final int consumedValue = consume(consumer);
+                int consumedValue = consume(consumer);
                 assertEquals(nextProducedValue - 1, consumedValue);
                 assertLag(0);
                 produce(producer);
@@ -62,9 +62,9 @@ public final class K3aLagExporterIT {
                 assertLag(2);
                 produce(producer);
                 assertLag(3);
-                consume(consumer);
-                consume(consumer);
-                consume(consumer);
+                do {
+                    consumedValue = consume(consumer);
+                } while (consumedValue < nextProducedValue - 1);
                 assertLag(0);
             }
         }
@@ -97,7 +97,7 @@ public final class K3aLagExporterIT {
 
     private int consume(final Consumer<Integer, Integer> consumer) {
         int lastValue = -1;
-        final ConsumerRecords<Integer, Integer> records = consumer.poll(Duration.ofMillis(300));
+        final ConsumerRecords<Integer, Integer> records = consumer.poll(Duration.ofMillis(1000));
         for (final ConsumerRecord<Integer, Integer> record : records) {
             lastValue = record.value();
             consumer.commitAsync();


### PR DESCRIPTION
We have three calls to `consume` in a row. Chances are that all three messages were received by the first call. The following calls will then wait for a second each before concluding that there are no messages.

This PR rewrites to not call `consume` more times than needed, potentially shaving off a couple of seconds in the integration test.

(The initial version of this PR reduced the poll time to something that proved too low when running on GitHub.)