### PR TITLE
ci(release-please): migrate to v4 (part 2)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   trigger:
     uses: statnett/github-workflows/.github/workflows/release-please.yaml@main
-    with:
-      release-type: maven
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
I missed removing an obsolete param.